### PR TITLE
New testing environment and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__/
 .idea/
 .vscode/
 .coverage
+.tox/
 storytellers_monolith.egg-info/
 storytellers.db

--- a/monolith/app.py
+++ b/monolith/app.py
@@ -7,20 +7,19 @@ from monolith.views import blueprints
 from monolith.auth import login_manager
 import datetime
 
-def create_app(test=False):
+def create_app(test=False, database=None, login_disabled=False):
     app = Flask(__name__)
     Bootstrap(app)
     app.config['WTF_CSRF_SECRET_KEY'] = 'A SECRET KEY'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SECRET_KEY'] = 'ANOTHER ONE'
     app.config['PERMANENT_SESSION_LIFETIME'] =  datetime.timedelta(minutes=120)
-    if not test:
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///storytellers.db'
-    else:
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///storytellers.db' if database is None else database
+    app.config['LOGIN_DISABLED'] = login_disabled
+    if test:
         app.config['TESTING'] = True
         app.config['WTF_CSRF_ENABLED'] = False
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-        app.config['LOGIN_DISABLED'] = True
+        # app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
 
     for bp in blueprints:
         app.register_blueprint(bp)
@@ -53,7 +52,6 @@ def create_app(test=False):
             example.text = 'Trial story of example admin user :)'
             example.likes = 42
             example.author_id = 1
-            print(example)
             db.session.add(example)
             db.session.commit()
 

--- a/monolith/app.py
+++ b/monolith/app.py
@@ -5,7 +5,7 @@ from flask import Flask
 from flask_bootstrap import Bootstrap
 
 from monolith.auth import login_manager
-from monolith.database import Story, User, db
+from monolith.database import User, db
 from monolith.views import blueprints
 
 

--- a/monolith/app.py
+++ b/monolith/app.py
@@ -1,25 +1,27 @@
-import os
-import shutil
-from flask import Flask
-from flask_bootstrap import Bootstrap
-from monolith.database import db, User, Story
-from monolith.views import blueprints
-from monolith.auth import login_manager
-import datetime
+import datetime as dt
 
-def create_app(test=False, database=None, login_disabled=False):
+from flask import Flask
+
+from flask_bootstrap import Bootstrap
+
+from monolith.auth import login_manager
+from monolith.database import Story, User, db
+from monolith.views import blueprints
+
+
+def create_app(test=False, database='sqlite:///storytellers.db',
+               login_disabled=False):
     app = Flask(__name__)
     Bootstrap(app)
     app.config['WTF_CSRF_SECRET_KEY'] = 'A SECRET KEY'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SECRET_KEY'] = 'ANOTHER ONE'
-    app.config['PERMANENT_SESSION_LIFETIME'] =  datetime.timedelta(minutes=120)
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///storytellers.db' if database is None else database
+    app.config['PERMANENT_SESSION_LIFETIME'] = dt.timedelta(minutes=120)
+    app.config['SQLALCHEMY_DATABASE_URI'] = database
     app.config['LOGIN_DISABLED'] = login_disabled
     if test:
         app.config['TESTING'] = True
         app.config['WTF_CSRF_ENABLED'] = False
-        # app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
 
     for bp in blueprints:
         app.register_blueprint(bp)
@@ -39,7 +41,7 @@ def create_app(test=False, database=None, login_disabled=False):
             example.firstname = 'Admin'
             example.lastname = 'Admin'
             example.email = 'example@example.com'
-            example.dateofbirth = datetime.datetime(2020, 10, 5)
+            example.dateofbirth = dt.datetime(2020, 10, 5)
             example.is_admin = True
             example.set_password('admin')
             db.session.add(example)

--- a/monolith/auth.py
+++ b/monolith/auth.py
@@ -1,5 +1,7 @@
 import functools
-from flask_login import current_user, LoginManager
+
+from flask_login import LoginManager, current_user
+
 from monolith.database import User
 
 
@@ -8,11 +10,11 @@ login_manager = LoginManager()
 
 def admin_required(func):
     @functools.wraps(func)
-    def _admin_required(*args, **kw):
+    def _admin_required(*args, **kwargs):
         admin = current_user.is_authenticated and current_user.is_admin
         if not admin:
             return login_manager.unauthorized()
-        return func(*args, **kw)
+        return func(*args, **kwargs)
     return _admin_required
 
 

--- a/monolith/classes/DiceSet.py
+++ b/monolith/classes/DiceSet.py
@@ -1,6 +1,7 @@
 import random as rnd
+
 from monolith.definitions import RESOURCES_DIR
-from monolith.utility.diceutils import get_dice_sets_lsit
+from monolith.utility.diceutils import get_dice_sets_list
 
 
 class Die:
@@ -8,19 +9,16 @@ class Die:
     def __init__(self, filename):
         self.faces = []
         self.pip = None
-        f = open(filename, "r")
-        lines = f.readlines()
-        for line in lines:
-            self.faces.append(line.replace("\n", ""))
-        self.throw_die()
-        f.close()
+        with open(filename, 'r') as f:
+            for line in f.readlines():
+                self.faces.append(line.replace('\n', ''))
+            self.throw_die()
 
     def throw_die(self):
-        if self.faces:  # pythonic for list is not empty
+        if self.faces:
             self.pip = rnd.choice(self.faces)
             return self.pip
-        else:
-            raise IndexError("throw_die(): empty die error.")
+        raise IndexError("throw_die(): empty die error.")
 
 
 class DiceSet:
@@ -32,14 +30,15 @@ class DiceSet:
         self.setname = setname
 
         # Check given parameters #
-        self._dice_preconditions(setname, dicenumber);
+        self._dice_preconditions(setname, dicenumber)
 
         # Create all the dice #
-        for i in range(0, dicenumber):
-            self.dice[i] = Die(RESOURCES_DIR + "/diceset/" + setname + "/die" + str(i) + ".txt")
+        for i in range(dicenumber):
+            path = '{}/diceset/{}/die{}.txt'.format(RESOURCES_DIR, setname, i)
+            self.dice[i] = Die(path)
 
     def throw_dice(self):
-        for i in range(0, self.dicenumber):
+        for i in range(self.dicenumber):
             self.pips[i] = self.dice[i].throw_die()
         return self.pips
 
@@ -47,11 +46,8 @@ class DiceSet:
         if dicenum < 4 or dicenum > 6:
             raise InvalidDiceSet()
 
-        if setname not in get_dice_sets_lsit():
+        if setname not in get_dice_sets_list():
             raise InvalidDiceSet(setname)
-
-
-
 
 
 class InvalidDiceSet(Exception):

--- a/monolith/classes/tests/test_dice.py
+++ b/monolith/classes/tests/test_dice.py
@@ -1,34 +1,36 @@
-from monolith.classes.DiceSet import DiceSet, Die, InvalidDiceSet
-from monolith.utility.diceutils import *
 import random as rnd
 import unittest
+
+from monolith.classes.DiceSet import DiceSet, Die, InvalidDiceSet
+from monolith.utility.diceutils import RESOURCES_DIR, get_die_faces_list
 
 
 class TestDie(unittest.TestCase):
 
     def test_create_dice_set_with_size(self):
-        diceset = DiceSet("standard", 6);
-        thrown = diceset.throw_dice();
-        self.assertEqual(len(thrown), 6);
+        diceset = DiceSet('standard', 6)
+        thrown = diceset.throw_dice()
+        self.assertEqual(len(thrown), 6)
 
-    # test for each die if the given face was in the list of all possible faces for that die #
+    # test for each die if the given face was in the list of all possible
+    # faces for that die #
     def test_correct_dices_thrown(self):
-        diceset = DiceSet("standard", 6);
-        thrown = diceset.throw_dice();
-        for i in range(0, 6):
-            face_list = get_die_faces_lsit("standard", i)
+        diceset = DiceSet('standard', 6)
+        thrown = diceset.throw_dice()
+        for i in range(6):
+            face_list = get_die_faces_list("standard", i)
             self.assertTrue(thrown[i] in face_list)
 
     def test_dice_set_not_exists_fail(self):
-        self.assertRaises(InvalidDiceSet, DiceSet, "LukeImYourFather", 6)
+        self.assertRaises(InvalidDiceSet, DiceSet, 'LukeImYourFather', 6)
 
     def test_die_init(self):
-        die = Die(RESOURCES_DIR + "/diceset/standard/die0.txt")
+        die = Die(RESOURCES_DIR + '/diceset/standard/die0.txt')
         check = ['bike', 'moonandstars', 'bag', 'bird', 'crying', 'angry']
         self.assertEqual(die.faces, check)
 
     def test_die_pip(self):
         rnd.seed(574891)
-        die = Die(RESOURCES_DIR + "/diceset/standard/die0.txt")
+        die = Die(RESOURCES_DIR + '/diceset/standard/die0.txt')
         res = die.throw_die()
         self.assertEqual(res, 'bag')

--- a/monolith/database.py
+++ b/monolith/database.py
@@ -1,17 +1,17 @@
-# -*- encoding: utf8 -*-
-from werkzeug.security import generate_password_hash, check_password_hash
-import enum
-from sqlalchemy.orm import relationship
 import datetime as dt
-from flask_sqlalchemy import SQLAlchemy
 from random import randint
+
+from flask_sqlalchemy import SQLAlchemy
+
+from werkzeug.security import check_password_hash, generate_password_hash
 
 db = SQLAlchemy()
 
 
 """Followers table, provides the many-to-many relationship between followers
 and followee. Primary key is composed by both the foreign keys."""
-followers = db.Table('followers',
+followers = db.Table(
+    'followers',
     db.Column('follower_id', db.Integer, db.ForeignKey('user.id'),
               primary_key=True),
     db.Column('followee_id', db.Integer, db.ForeignKey('user.id'),
@@ -42,7 +42,7 @@ class User(db.Model):
                               backref=db.backref('followed', lazy=True))
 
     def __init__(self, *args, **kw):
-        super(User, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self._authenticated = False
 
     def set_password(self, password):
@@ -65,28 +65,30 @@ class User(db.Model):
 class Story(db.Model):
     __tablename__ = 'story'
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    text = db.Column(db.Text(1000)) # around 200 (English) words
+    text = db.Column(db.Text(1000))  # around 200 (English) words
     date = db.Column(db.DateTime)
-    likes = db.Column(db.Integer)  # will store the number of likes, periodically updated in background
+    # will store the number of likes, periodically updated in background
+    likes = db.Column(db.Integer)
     # define foreign key
     author_id = db.Column(db.Integer, db.ForeignKey('user.id'))
-    author = relationship('User', foreign_keys='Story.author_id')
+    author = db.relationship('User', foreign_keys='Story.author_id')
 
     def __init__(self, *args, **kw):
-        super(Story, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
         self.date = dt.datetime.now()
 
 
 class Like(db.Model):
     __tablename__ = 'like'
+    liker_id = db.Column(db.Integer, db.ForeignKey('user.id'),
+                         primary_key=True)
+    liker = db.relationship('User', foreign_keys='Like.liker_id')
+    story_id = db.Column(db.Integer, db.ForeignKey('story.id'),
+                         primary_key=True)
+    author = db.relationship('Story', foreign_keys='Like.story_id')
+    # TODO: duplicated ?
+    liked_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    liker = db.relationship('User', foreign_keys='Like.liker_id')
 
-    liker_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
-    liker = relationship('User', foreign_keys='Like.liker_id')
-
-    story_id = db.Column(db.Integer, db.ForeignKey('story.id'), primary_key=True)
-    author = relationship('Story', foreign_keys='Like.story_id')
-
-    liked_id = db.Column(db.Integer, db.ForeignKey('user.id')) # TODO: duplicated ?
-    liker = relationship('User', foreign_keys='Like.liker_id')
-
-    marked = db.Column(db.Boolean, default = False) # True iff it has been counted in Story.likes
+    # True iff it has been counted in Story.likes
+    marked = db.Column(db.Boolean, default=False)

--- a/monolith/database.py
+++ b/monolith/database.py
@@ -88,7 +88,7 @@ class Like(db.Model):
     author = db.relationship('Story', foreign_keys='Like.story_id')
     # TODO: duplicated ?
     liked_id = db.Column(db.Integer, db.ForeignKey('user.id'))
-    liker = db.relationship('User', foreign_keys='Like.liker_id')
+    liked = db.relationship('User', foreign_keys='Like.liked_id')
 
     # True iff it has been counted in Story.likes
     marked = db.Column(db.Boolean, default=False)

--- a/monolith/definitions.py
+++ b/monolith/definitions.py
@@ -1,4 +1,4 @@
 import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-RESOURCES_DIR = ROOT_DIR + "/resources"
+RESOURCES_DIR = ROOT_DIR + '/resources'

--- a/monolith/forms.py
+++ b/monolith/forms.py
@@ -1,30 +1,57 @@
 from flask_wtf import FlaskForm
+
 import wtforms as f
-from wtforms.fields.html5 import EmailField, DateField
-from wtforms.validators import DataRequired, Email, Length, Regexp, Optional
+from wtforms.fields.html5 import DateField, EmailField
+from wtforms.validators import DataRequired, Email, Length, Optional, Regexp
 
 
 class LoginForm(FlaskForm):
-    usrn_eml = f.StringField('E-mail or username', id='usrn_eml', validators=[DataRequired()])
-    password = f.PasswordField('Password', id='password', validators=[DataRequired()])
+    usrn_eml = f.StringField('E-mail or username',
+                             id='usrn_eml',
+                             validators=[DataRequired()])
+    password = f.PasswordField('Password',
+                               id='password',
+                               validators=[DataRequired()])
     display = ['usrn_eml', 'password']
 
 
 class UserForm(FlaskForm):
-    email = EmailField('E-mail*', id='email', validators=[DataRequired(), Email()])
-    username = f.StringField('Username*',
-                            id='username',
-                            validators=[DataRequired(),
-                                        Regexp('^\w+$', message="Username must contain only letters, numbers or underscore."),
-                                        Length(min=5, max=25, message="Username must be betwen 5 and 25 characters")])
-    password = f.PasswordField('Password*', id='password', validators=[DataRequired(), Length(min=8, max=64)])
-    firstname = f.StringField('First Name', id='firstname', validators=[Length(max=64), Optional()])
-    lastname = f.StringField('Last Name', id='lastname', validators=[Length(max=64), Optional()])
-    dateofbirth = DateField('Date of Birth', id='dateofbirth', validators=[Optional()])
-    display = ['email', 'username', 'password','firstname', 'lastname', 'dateofbirth']
+    email = EmailField('E-mail*',
+                       id='email',
+                       validators=[DataRequired(), Email()])
+    user_regexp = Regexp(
+        '^\w+$',
+        message='Username must contain only letters, numbers or underscore.')
+    user_length = Length(
+        min=5, max=25, message='Username must be betwen 5 and 25 characters')
+    username = f.StringField(
+        'Username*',
+        id='username',
+        validators=[DataRequired(), user_regexp])
+    password = f.PasswordField(
+        'Password*',
+        id='password',
+        validators=[DataRequired(), Length(min=8, max=64)])
+    firstname = f.StringField(
+        'First Name',
+        id='firstname',
+        validators=[Length(max=64), Optional()])
+    lastname = f.StringField(
+        'Last Name',
+        id='lastname',
+        validators=[Length(max=64), Optional()])
+    dateofbirth = DateField(
+        'Date of Birth',
+        id='dateofbirth',
+        validators=[Optional()])
+    display = ['email', 'username', 'password',
+               'firstname', 'lastname', 'dateofbirth']
 
 
 class StoryForm(FlaskForm):
-    diceset = ""
-    text = f.TextAreaField('Write your story', id='text', validators=[DataRequired(), Length(max=1000)])
+    diceset = ''
+    text = f.TextAreaField(
+        'Write your story',
+        id='text',
+        validators=[DataRequired(), Length(max=1000)])
     display = ['text']

--- a/monolith/tests/conftest.py
+++ b/monolith/tests/conftest.py
@@ -1,0 +1,97 @@
+import datetime
+import os
+import tempfile
+
+import pytest
+
+from monolith.app import create_app
+from monolith.database import db, User
+
+
+@pytest.fixture
+def app():
+    """Create and configure a new app instance for each test."""
+    from monolith.app import create_app
+    db_fd, db_path = tempfile.mkstemp()
+    db_url = 'sqlite:///' + db_path
+    app = create_app(test=True, database=db_url)
+
+    yield app
+
+    os.close(db_fd)
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _init_database(db):
+    example1 = User()
+    example1.username = 'test1'
+    example1.firstname = 'First1'
+    example1.lastname = 'Last1'
+    example1.email = 'test1@example.com'
+    example1.dateofbirth = datetime.datetime(2020, 10, 5)
+    example1.is_admin = False
+    example1.set_password('test1123')
+    db.session.add(example1)
+
+    example2 = User()
+    example2.username = 'test2'
+    example2.firstname = 'First2'
+    example2.lastname = 'Last2'
+    example2.email = 'test2@example.com'
+    example2.dateofbirth = datetime.datetime(2020, 10, 5)
+    example2.is_admin = False
+    example2.set_password('test2123')
+    db.session.add(example2)
+
+    example3 = User()
+    example3.username = 'test3'
+    example3.firstname = 'First3'
+    example3.lastname = 'Last3'
+    example3.email = 'test3@example.com'
+    example3.dateofbirth = datetime.datetime(2020, 10, 5)
+    example3.is_admin = False
+    example3.set_password('test3123')
+    db.session.add(example3)
+
+    db.session.commit()
+
+@pytest.fixture
+def database(app):
+    with app.app_context():
+        db.create_all()
+
+        _init_database(db)
+        yield db
+
+        db.drop_all()
+        db.session.commit()
+
+
+class AuthActions:
+
+    def __init__(self, app, client):
+        self._app = app
+        self._client = client
+
+    def disable(self):
+        self._app.config['LOGIN_DISABLED'] = True
+
+    def enable(self):
+        self._app.config['LOGIN_DISABLED'] = False
+
+    def login(self, username='Admin', password='admin'):
+        return self._client.post('/login',
+                                 data={'usrn_eml': username, 'password': password})
+
+    def logout(self):
+        return self._client.get('/logout')
+
+
+@pytest.fixture
+def auth(app, client):
+    return AuthActions(app, client)

--- a/monolith/tests/conftest.py
+++ b/monolith/tests/conftest.py
@@ -3,16 +3,16 @@ import os
 import tempfile
 
 from flask import template_rendered
-import pytest
 
 from monolith.app import create_app
-from monolith.database import db, User
+from monolith.database import User, db
+
+import pytest
 
 
 @pytest.fixture
 def app():
     """Create and configure a new app instance for each test."""
-    from monolith.app import create_app
     db_fd, db_path = tempfile.mkstemp()
     db_url = 'sqlite:///' + db_path
     app = create_app(test=True, database=db_url)
@@ -61,6 +61,7 @@ def _init_database(db):
 
     db.session.commit()
 
+
 @pytest.fixture
 def database(app):
     with app.app_context():
@@ -80,8 +81,8 @@ class AuthActions:
         self._client = client
 
     def login(self, username='Admin', password='admin'):
-        return self._client.post('/login',
-                                 data={'usrn_eml': username, 'password': password})
+        return self._client.post('/login', data={
+            'usrn_eml': username, 'password': password})
 
     def logout(self):
         return self._client.get('/logout')
@@ -91,7 +92,7 @@ class AuthActions:
 def auth(app, client):
     return AuthActions(app, client)
 
-# blinker is required
+
 @pytest.fixture
 def templates(app):
     recorded = []

--- a/monolith/tests/test_auth.py
+++ b/monolith/tests/test_auth.py
@@ -1,11 +1,5 @@
-from unittest import TestCase
-from monolith.forms import LoginForm, UserForm
-from flask import request
-from flask_login import current_user
-import json
+from monolith.database import User
 
-from monolith.app import create_app
-from monolith.database import db, User, Story
 
 def test_signup(client, database):
     reply = client.get('/signup')
@@ -20,18 +14,18 @@ def test_signup(client, database):
     user = database.session.query(User).filter_by(username='prova').one()
     assert [user.username, user.email] == ['prova', 'prova@prova.com']
 
-
     reply = client.post('/signup', data={'email': 'prova@prova.com',
                                          'username': 'prova',
                                          'password': 'prova123'})
-    assert reply.get_json() == {'Error':'This email is already used.'}
+    assert reply.get_json() == {'Error': 'This email is already used.'}
     database.session.rollback()
 
     reply = client.post('/signup', data={'email': 'prova2@prova.com',
                                          'username': 'prova',
                                          'password': 'prova123'})
-    assert reply.get_json() == {'Error':'This username already exists.'}
+    assert reply.get_json() == {'Error': 'This username already exists.'}
     database.session.rollback()
+
 
 def test_auth(client, database):
     reply = client.post('/signup', data={'email': 'prova@prova.com',

--- a/monolith/tests/test_auth.py
+++ b/monolith/tests/test_auth.py
@@ -7,82 +7,66 @@ import json
 from monolith.app import create_app
 from monolith.database import db, User, Story
 
-class AuthUnittest(TestCase):
-    def setUp(self):
-        self.app = create_app(test=True)
-        self.context = self.app.app_context()
-        self.app = self.app.test_client()
+def test_signup(client, database):
+    reply = client.get('/signup')
+    assert reply.status_code == 200
 
-    def tearDown(self):
-        with self.context:
-            db.drop_all()
+    reply = client.post('/signup', data={'email': 'prova@prova.com',
+                                         'username': 'prova',
+                                         'password': 'prova123'})
 
-    def test_signup(self):
-        reply = self.app.get('/signup')
-        self.assertEqual(reply.status_code, 200)
+    assert reply.status_code == 302
 
-        reply = self.app.post('/signup', data={'email': 'prova@prova.com',
-                                          'username': 'prova',
-                                          'password': 'prova123'})
-
-        self.assertEqual(reply.status_code, 302)
-
-        with self.context:
-            users = db.session.query(User).filter_by(username="prova")
-            u = users.first()
-
-        self.assertEqual([u.username, u.email], ["prova", "prova@prova.com"])
+    user = database.session.query(User).filter_by(username='prova').one()
+    assert [user.username, user.email] == ['prova', 'prova@prova.com']
 
 
-        reply = self.app.post('/signup', data={'email': 'prova@prova.com',
-                                          'username': 'prova',
-                                          'password': 'prova123'})
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body, {'Error':'This email is already used.'})
+    reply = client.post('/signup', data={'email': 'prova@prova.com',
+                                         'username': 'prova',
+                                         'password': 'prova123'})
+    assert reply.get_json() == {'Error':'This email is already used.'}
+    database.session.rollback()
 
-        reply = self.app.post('/signup', data={'email': 'prova2@prova.com',
-                                          'username': 'prova',
-                                          'password': 'prova123'})
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body, {'Error':'This username already exists.'})
+    reply = client.post('/signup', data={'email': 'prova2@prova.com',
+                                         'username': 'prova',
+                                         'password': 'prova123'})
+    assert reply.get_json() == {'Error':'This username already exists.'}
+    database.session.rollback()
 
-    def test_auth(self):
-        reply = self.app.post('/signup', data={'email': 'prova@prova.com',
-                                          'username': 'prova',
-                                          'password': 'prova123'})
+def test_auth(client, database):
+    reply = client.post('/signup', data={'email': 'prova@prova.com',
+                                         'username': 'prova',
+                                         'password': 'prova123'})
+    assert reply.status_code == 302
 
-        self.assertEqual(reply.status_code, 302)
+    reply = client.get('/logout')
+    assert reply.status_code == 302
 
-        reply = self.app.get('/logout')
-        self.assertEqual(reply.status_code, 302)
+    reply = client.get('/logout')
+    assert reply.status_code == 203
 
-        reply = self.app.get('/logout')
-        self.assertEqual(reply.status_code, 203)
+    reply = client.get('/login')
+    assert reply.status_code == 200
 
-        reply = self.app.get('/login')
-        self.assertEqual(reply.status_code, 200)
+    reply = client.post('/login', data={'usrn_eml': 'prova@prova.com',
+                                        'password': 'prova123'})
+    assert reply.status_code == 302
 
-        reply = self.app.post('/login', data={'usrn_eml': 'prova@prova.com',
-                                          'password': 'prova123'})
-        self.assertEqual(reply.status_code, 302)
+    reply = client.post('/login', data={'usrn_eml': 'prova',
+                                        'password': 'prova123'})
+    assert reply.status_code == 302
 
-        reply = self.app.post('/login', data={'usrn_eml': 'prova',
-                                          'password': 'prova123'})
-        self.assertEqual(reply.status_code, 302)
+    reply = client.post('/login', data={'usrn_eml': 'Admin',
+                                        'password': 'admin'})
+    assert reply.status_code == 302
 
-        reply = self.app.post('/login', data={'usrn_eml': 'Admin',
-                                          'password': 'admin'})
-        self.assertEqual(reply.status_code, 302)
+    reply = client.get('/logout')
+    assert reply.status_code == 302
 
-        reply = self.app.get('/logout')
-        self.assertEqual(reply.status_code, 302)
+    reply = client.post('/login', data={'usrn_eml': 'Admin',
+                                        'password': 'boh'})
+    assert reply.get_json() == {'Error': 'Wrong username or password.'}
 
-        reply = self.app.post('/login', data={'usrn_eml': 'Admin',
-                                          'password': 'boh'})
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body, {'Error': 'Wrong username or password.'})
-
-        reply = self.app.post('/login', data={'usrn_eml': 'boh',
-                                          'password': 'admin'})
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body, {'Error': 'Wrong username or password.'})
+    reply = client.post('/login', data={'usrn_eml': 'boh',
+                                        'password': 'admin'})
+    assert reply.get_json() == {'Error': 'Wrong username or password.'}

--- a/monolith/tests/test_follow.py
+++ b/monolith/tests/test_follow.py
@@ -2,6 +2,16 @@ from monolith.database import User
 
 
 def test_follow_post(client, database, auth):
+    """Tests the POST endpoint of a follow request.
+    This tests use the fixtures defined in conftest.py extensively. Using a
+    fixtures is as simple as defining a parameter with the same name in the
+    function definition. auth is used for login, while client is used for the
+    requests, with database to check that the calls are functioning correctly.
+    Instead of defining a subclass of unittest.TestCase, asserts are used in
+    the same manner of assertEqual. If assertRaises is needed, pytest.raises
+    may be imported. All contexts management, login and templates are managed
+    by the fixtures.
+    """
     reply = auth.login('test1', 'test1123')
     assert reply.status_code == 302
 
@@ -33,6 +43,7 @@ def test_follow_post(client, database, auth):
 
 
 def test_follow_delete(client, database, auth):
+    """Tests the DELETE endpoint of a unfollow request."""
     reply = auth.login('test1', 'test1123')
     assert reply.status_code == 302
 
@@ -69,6 +80,10 @@ def test_follow_delete(client, database, auth):
 
 
 def test_followed_get(client, database, auth, templates):
+    """Test the view the returns the list of followed users.
+    Notably, the templates capturing fixtures is used with templates[-1] to
+    retrieve the last request template context.
+    """
     reply = auth.login('test1', 'test1123')
     assert reply.status_code == 302
 
@@ -93,7 +108,6 @@ def test_followed_get(client, database, auth, templates):
 
     reply = client.get('/followed')
     assert reply.status_code == 200
-    assert templates
     users = templates[-1]['users']
     assert len(users) == 1
     assert users[0] == user1

--- a/monolith/tests/test_follow.py
+++ b/monolith/tests/test_follow.py
@@ -74,7 +74,7 @@ def test_follow_delete(client, database, auth):
     assert reply.get_json()['error'] == 'Cannot follow or unfollow yourself'
 
 
-def test_followed_get(client, database, auth):
+def test_followed_get(client, database, auth, templates):
     reply = auth.login('test1', 'test1123')
     assert reply.status_code == 302
 
@@ -86,18 +86,20 @@ def test_followed_get(client, database, auth):
 
     reply = client.get('/followed')
     assert reply.status_code == 200
-    reply_users = reply.get_json()['users']
-    assert len(reply_users) == 2
+    assert templates
+    users = templates[-1]['users']
+    assert len(users) == 2
     user1 = {'firstname': 'Admin', 'lastname': 'Admin', 'id': 1}
     user3 = {'firstname': 'First2', 'lastname': 'Last2', 'id': 3}
-    assert reply_users[0] == user1
-    assert reply_users[1] == user3
+    assert users[0] == user1
+    assert users[1] == user3
 
     reply = client.delete('/users/3/follow')
     assert reply.status_code == 200
 
     reply = client.get('/followed')
     assert reply.status_code == 200
-    reply_users = reply.get_json()['users']
-    assert len(reply_users) == 1
-    assert reply_users[0] == user1
+    assert templates
+    users = templates[-1]['users']
+    assert len(users) == 1
+    assert users[0] == user1

--- a/monolith/tests/test_follow.py
+++ b/monolith/tests/test_follow.py
@@ -1,151 +1,103 @@
 from unittest import TestCase
 from flask import request
-from flask_login import (current_user, login_user)
+from flask_login import current_user
 import json
 
 from monolith.app import create_app
-from monolith.database import db, User
+from monolith.database import User
 
 
-class TestFollowers(TestCase):
+def test_follow_post(client, database, auth):
+    reply = auth.login('test1', 'test1123')
+    assert reply.status_code == 302
 
-    def setUp(self):
-        self.app = create_app(test=True)
-        self.context = self.app.app_context()
-        self.app = self.app.test_client()
+    reply = client.post('/users/1/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User followed'
 
-        with self.context:
-            u = User(username='test1', email='test1@example.com', firstname='FirstTest1', lastname='LastTest1')
-            u.set_password('test1123')
-            db.session.add(u)
-            u = User(username='test2', email='test2@example.com', firstname='FirstTest2', lastname='LastTest2')
-            u.set_password('test2123')
-            db.session.add(u)
-            u = User(username='test3', email='test3@example.com', firstname='FirstTest3', lastname='LastTest3')
-            u.set_password('test3123')
-            db.session.add(u)
-            db.session.commit()
+    reply = client.post('/users/3/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User followed'
 
-    def tearDown(self):
-        with self.context:
-            db.drop_all()
+    user1 = database.session.query(User).filter_by(username='test1').one()
+    assert len(user1.follows) == 2
 
-    def test_follow_post(self):
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
+    reply = client.post('/users/3/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User followed'
 
-        reply = self.app.post(
-            '/login', data={'usrn_eml': 'test1@example.com', 'password': 'test1123'})
-        self.assertEqual(reply.status_code, 302)
+    user1 = database.session.query(User).filter_by(username='test1').one()
+    assert len(user1.follows) == 2
 
-        reply = self.app.post('/users/1/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User followed')
+    reply = client.post('/users/5/follow')
+    assert reply.status_code == 404
+    assert reply.get_json()['error'] == 'User with id 5 does not exists'
 
-        reply = self.app.post('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User followed')
+    reply = client.post('/users/2/follow')
+    assert reply.status_code == 400
+    assert reply.get_json()['error'] == 'Cannot follow or unfollow yourself'
 
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
-            self.assertEqual(len(u.follows), 2)
 
-        reply = self.app.post('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User followed')
+def test_follow_delete(client, database, auth):
+    reply = auth.login('test1', 'test1123')
+    assert reply.status_code == 302
 
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
-            self.assertEqual(len(u.follows), 2)
+    reply = client.post('/users/1/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User followed'
 
-        reply = self.app.post('/users/5/follow')
-        self.assertEqual(reply.status_code, 404)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['error'], 'User with id 5 does not exists')
+    reply = client.post('/users/3/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User followed'
 
-        reply = self.app.post('/users/2/follow')
-        self.assertEqual(reply.status_code, 400)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['error'], 'Cannot follow or unfollow yourself')
+    user1 = database.session.query(User).filter_by(username='test1').one()
+    assert len(user1.follows) == 2
 
-    def test_follow_delete(self):
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
+    reply = client.delete('/users/3/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User unfollowed'
 
-        reply = self.app.post(
-            '/login', data={'usrn_eml': 'test1@example.com', 'password': 'test1123'})
-        self.assertEqual(reply.status_code, 302)
+    user1 = database.session.query(User).filter_by(username='test1').one()
+    assert len(user1.follows) == 1
+    assert user1.follows[0].username == 'Admin'
 
-        reply = self.app.post('/users/1/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User followed')
+    reply = client.delete('/users/3/follow')
+    assert reply.status_code == 200
+    assert reply.get_json()['message'] == 'User unfollowed'
 
-        reply = self.app.post('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User followed')
+    reply = client.delete('/users/5/follow')
+    assert reply.status_code == 404
+    assert reply.get_json()['error'] == 'User with id 5 does not exists'
 
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
-            self.assertEqual(len(u.follows), 2)
+    reply = client.post('/users/2/follow')
+    assert reply.status_code == 400
+    assert reply.get_json()['error'] == 'Cannot follow or unfollow yourself'
 
-        reply = self.app.delete('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User unfollowed')
 
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
-            self.assertEqual(len(u.follows), 1)
-            self.assertEqual(u.follows[0].username, 'Admin')
+def test_followed_get(client, database, auth):
+    reply = auth.login('test1', 'test1123')
+    assert reply.status_code == 302
 
-        reply = self.app.delete('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['message'], 'User unfollowed')
+    reply = client.post('/users/1/follow')
+    assert reply.status_code == 200
 
-        reply = self.app.delete('/users/5/follow')
-        self.assertEqual(reply.status_code, 404)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['error'], 'User with id 5 does not exists')
+    reply = client.post('/users/3/follow')
+    assert reply.status_code == 200
 
-        reply = self.app.post('/users/2/follow')
-        self.assertEqual(reply.status_code, 400)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(body['error'], 'Cannot follow or unfollow yourself')
+    reply = client.get('/followed')
+    assert reply.status_code == 200
+    reply_users = reply.get_json()['users']
+    assert len(reply_users) == 2
+    user1 = {'firstname': 'Admin', 'lastname': 'Admin', 'id': 1}
+    user3 = {'firstname': 'First2', 'lastname': 'Last2', 'id': 3}
+    assert reply_users[0] == user1
+    assert reply_users[1] == user3
 
-    def test_followed_get(self):
-        with self.context:
-            u = db.session.query(User).filter_by(username='test1').one()
+    reply = client.delete('/users/3/follow')
+    assert reply.status_code == 200
 
-        reply = self.app.post(
-            '/login', data={'usrn_eml': 'test1@example.com', 'password': 'test1123'})
-        self.assertEqual(reply.status_code, 302)
-
-        reply = self.app.post('/users/1/follow')
-        self.assertEqual(reply.status_code, 200)
-
-        reply = self.app.post('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-
-        reply = self.app.get('/followed')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(len(body['users']), 2)
-        user1 = {'firstname': 'Admin', 'lastname': 'Admin', 'id': 1}
-        user3 = {'firstname': 'FirstTest2', 'lastname': 'LastTest2', 'id': 3}
-        self.assertEqual(body['users'][0], user1)
-        self.assertEqual(body['users'][1], user3)
-
-        reply = self.app.delete('/users/3/follow')
-        self.assertEqual(reply.status_code, 200)
-
-        reply = self.app.get('/followed')
-        self.assertEqual(reply.status_code, 200)
-        body = json.loads(str(reply.data, 'utf8'))
-        self.assertEqual(len(body['users']), 1)
-        self.assertEqual(body['users'][0], user1)
+    reply = client.get('/followed')
+    assert reply.status_code == 200
+    reply_users = reply.get_json()['users']
+    assert len(reply_users) == 1
+    assert reply_users[0] == user1

--- a/monolith/tests/test_follow.py
+++ b/monolith/tests/test_follow.py
@@ -1,9 +1,3 @@
-from unittest import TestCase
-from flask import request
-from flask_login import current_user
-import json
-
-from monolith.app import create_app
 from monolith.database import User
 
 

--- a/monolith/tests/test_get_story.py
+++ b/monolith/tests/test_get_story.py
@@ -6,40 +6,30 @@ from monolith.database import db, User, Story
 from monolith.views.stories import _get_story
 from monolith.app import create_app
 
-class TestGetStory(unittest.TestCase):
-    def setUp(self):
-        self.app = create_app(test=True)
-        self.context = self.app.app_context()
-        self.app = self.app.test_client()
+def test_get_story(client):
+    #story found
+    reply = client.get('/stories/1')
+    body = reply.get_json()
 
-    def tearDown(self):
-        with self.context:
-            db.drop_all()
-    
-    def test_get_story(self):
-        #story found
-        reply = self.app.get('/stories/1')
-        body = json.loads(str(reply.data, 'utf8'))
-        
-        self.assertEqual(body['story'], '1')
-        self.assertEqual(body['message'], '')
-        self.assertEqual(reply.status_code, 200)
-        #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5></h5>\n    <ul>\n      \n      <li>\n      \"Trial story of example admin user :)\"    Likes: 42 (2019-10-27 21:09:18.895015)\n      \n      </li>\n      \n    </ul>\n  </body>\n</html>')
+    assert body['story'] == '1'
+    assert body['message'] == ''
+    assert reply.status_code == 200
+    #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5></h5>\n    <ul>\n      \n      <li>\n      \"Trial story of example admin user :)\"    Likes: 42 (2019-10-27 21:09:18.895015)\n      \n      </li>\n      \n    </ul>\n  </body>\n</html>')
 
-        #story not found
-        reply = self.app.get('/stories/0')
-        body = json.loads(str(reply.data, 'utf8'))
-        
-        self.assertEqual(body['story'], 'None')
-        self.assertEqual(body['message'], 'story not found!')
-        self.assertEqual(reply.status_code, 200)
-        #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5>story not found!</h5>\n    <ul>\n      \n    </ul>\n  </body>\n</html>')
+    #story not found
+    reply = client.get('/stories/0')
+    body = reply.get_json()
 
-        #invalid input
-        reply = self.app.get('stories/ciao')
-        body = json.loads(str(reply.data, 'utf8'))
-        
-        self.assertEqual(body['story'], 'None')
-        self.assertEqual(body['message'], 'story not found!')
-        self.assertEqual(reply.status_code, 200)
-        #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5>story not found!</h5>\n    <ul>\n      \n    </ul>\n  </body>\n</html>')
+    assert body['story'] == 'None'
+    assert body['message'] == 'story not found!'
+    assert reply.status_code == 200
+    #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5>story not found!</h5>\n    <ul>\n      \n    </ul>\n  </body>\n</html>')
+
+    #invalid input
+    reply = client.get('stories/ciao')
+    body = reply.get_json()
+
+    assert body['story'] == 'None'
+    assert body['message'] == 'story not found!'
+    assert reply.status_code == 200
+    #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5>story not found!</h5>\n    <ul>\n      \n    </ul>\n  </body>\n</html>')

--- a/monolith/tests/test_get_story.py
+++ b/monolith/tests/test_get_story.py
@@ -1,35 +1,24 @@
-import unittest
-import json
-from flask import request, jsonify
-
-from monolith.database import db, User, Story
-from monolith.views.stories import _get_story
-from monolith.app import create_app
-
 def test_get_story(client):
-    #story found
+    # story found
     reply = client.get('/stories/1')
     body = reply.get_json()
 
     assert body['story'] == '1'
     assert body['message'] == ''
     assert reply.status_code == 200
-    #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5></h5>\n    <ul>\n      \n      <li>\n      \"Trial story of example admin user :)\"    Likes: 42 (2019-10-27 21:09:18.895015)\n      \n      </li>\n      \n    </ul>\n  </body>\n</html>')
 
-    #story not found
+    # story not found
     reply = client.get('/stories/0')
     body = reply.get_json()
 
     assert body['story'] == 'None'
     assert body['message'] == 'story not found!'
     assert reply.status_code == 200
-    #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5>story not found!</h5>\n    <ul>\n      \n    </ul>\n  </body>\n</html>')
 
-    #invalid input
+    # invalid input
     reply = client.get('stories/ciao')
     body = reply.get_json()
 
     assert body['story'] == 'None'
     assert body['message'] == 'story not found!'
     assert reply.status_code == 200
-    #OLD ASSERTION self.assertEqual(data, '<html>\n  <body>\n    <h1>Story List</h1>\n    <h5>story not found!</h5>\n    <ul>\n      \n    </ul>\n  </body>\n</html>')

--- a/monolith/tests/test_stories.py
+++ b/monolith/tests/test_stories.py
@@ -1,37 +1,15 @@
-from unittest import TestCase
-from monolith.forms import LoginForm, UserForm
-from flask import request
-from flask_login import current_user
-import json
-import unittest
+from monolith.database import Story
 
-from monolith.app import create_app
-from monolith.database import db, User, Story
 
-class StoriesUnittest(TestCase):
-    def setUp(self):
-        self.app = create_app(test=True)
-        self.context = self.app.app_context()
-        self.app = self.app.test_client()
+def test_write_new_story(client, auth, database):
+    auth.login('Admin', 'admin')
 
-    def tearDown(self):
-        with self.context:
-            db.drop_all()
+    reply = client.post('/writeStory', data={'text': 'test story'})
+    assert reply.status_code == 200
 
-    def test_write_new_story(self):
-        self.app.post('/login', data={'usrn_eml': 'Admin', 'password': 'admin'})
+    story = database.session.query(Story).order_by(Story.date.desc()).first()
+    assert story.text == "test story"
+    assert story.author_id == 1
 
-        reply = self.app.post('/writeStory', data={'text': 'test story'})
-
-        self.assertEqual(reply.status_code, 200)
-
-        with self.context:
-            stories = db.session.query(Story).order_by(Story.date.desc())
-            s = stories.first()
-
-        self.assertEqual(s.text, "test story")
-        self.assertEqual(s.author_id, 1)
-
-        reply = self.app.post('/writeStory', data={})
-
-        self.assertEqual(reply.status_code, 400)
+    reply = client.post('/writeStory', data={})
+    assert reply.status_code == 400

--- a/monolith/tests/test_unitStories.py
+++ b/monolith/tests/test_unitStories.py
@@ -1,92 +1,79 @@
-import unittest
+import os
+import tempfile
+
+import pytest
 
 from kombu.utils import json
 from monolith.utility.diceutils import *
 
-from monolith import app as test_app
+
+@pytest.fixture
+def app():
+    """Create and configure a new app instance for each test."""
+    from monolith.app import create_app
+    db_fd, db_path = tempfile.mkstemp()
+    db_url = 'sqlite:///' + db_path
+    app = create_app(test=True, database=db_url, login_disabled=True)
+
+    yield app
+
+    os.close(db_fd)
+    os.unlink(db_path)
 
 
-class TestApp(unittest.TestCase):
+def test_newStory(client):
+    # new story page
+    reply = client.get('/newStory')
+    assert reply.status_code == 200
 
-    def test_newStory(self):
-        app = test_app.create_app(test=True)
-        tested_app = app.test_client()
+def test_roll_valid_dice_success(client):
+    reply = client.get('/rollDice?diceset=standard')
+    assert reply.status_code == 200
 
-        # new story page
-        reply = tested_app.get('/newStory')
-        self.assertEqual(reply.status_code, 200)
+def test_roll_invalid_dice_fail(client):
+    # new story page
+    reply = client.get('/rollDice?diceset=LukeImYourFather')
+    assert reply.status_code == 400
 
-    def test_roll_valid_dice_success(self):
-        app = test_app.create_app(test=True)
-        tested_app = app.test_client()
+    # 3 standard dice
+    reply = client.get('/rollDice?diceset=standard&dicenum=3')
+    assert reply.status_code == 400
 
-        # new story page
-        reply = tested_app.get('/rollDice?diceset=standard')
-        self.assertEqual(reply.status_code, 200)
+    # -1 standard dice
+    reply = client.get('/rollDice?diceset=standard&dicenum=-1')
+    assert reply.status_code == 400
 
-    def test_roll_invalid_dice_fail(self):
-        app = test_app.create_app(test=True)
-        tested_app = app.test_client()
+    # 0 standard dice
+    reply = client.get('/rollDice?diceset=standard&dicenum=0')
+    assert reply.status_code == 400
 
-        # new story page
-        reply = tested_app.get('/rollDice?diceset=LukeImYourFather')
-        self.assertEqual(reply.status_code, 400)
+def test_roll_dice_standard(client):
+    # 6 standard dice
+    reply = client.get('/rollDice?diceset=standard')
+    assert len(reply.get_json()) == 6
 
-        # 3 standard dice
-        reply = tested_app.get('/rollDice?diceset=standard&dicenum=3')
-        self.assertEqual(reply.status_code, 400)
+    # 5 standard dice
+    reply = client.get('/rollDice?diceset=standard&dicenum=5')
+    assert len(reply.get_json()) == 5
 
-        # -1 standard dice
-        reply = tested_app.get('/rollDice?diceset=standard&dicenum=-1')
-        self.assertEqual(reply.status_code, 400)
+    # 4 standard dice
+    reply = client.get('/rollDice?diceset=standard&dicenum=4')
+    assert len(reply.get_json()) == 4
 
-        # 0 standard dice
-        reply = tested_app.get('/rollDice?diceset=standard&dicenum=0')
-        self.assertEqual(reply.status_code, 400)
+def test_roll_dice_halloween(client):
+    # dice thrown in halloween set
+    reply = client.get('/rollDice?diceset=halloween')
+    body = reply.get_json()
+    assert len(body) == 6
+    for i in range(0, 6):
+        face_list = get_die_faces_lsit("halloween", i)
+        assert body[i] in face_list
 
-    def test_roll_dice_standard(self):
-        app = test_app.create_app(test=True)
-        tested_app = app.test_client()
-
-        # 6 standard dice
-        reply = tested_app.get('/rollDice?diceset=standard')
-        body = json.loads(str(reply.data, 'UTF8'))
-        self.assertEqual(len(body), 6)
-
-        # 5 standard dice
-        reply = tested_app.get('/rollDice?diceset=standard&dicenum=5')
-        body = json.loads(str(reply.data, 'UTF8'))
-        self.assertEqual(len(body), 5)
-
-        # 4 standard dice
-        reply = tested_app.get('/rollDice?diceset=standard&dicenum=4')
-        body = json.loads(str(reply.data, 'UTF8'))
-        self.assertEqual(len(body), 4)
-
-    def test_roll_dice_halloween(self):
-        app = test_app.create_app(test=True)
-        tested_app = app.test_client()
-
-        # dice thrown in halloween set
-        reply = tested_app.get('/rollDice?diceset=halloween')
-        body = json.loads(str(reply.data, 'UTF8'))
-        self.assertEqual(len(body), 6)
-        for i in range(0, 6):
-            face_list = get_die_faces_lsit("halloween", i)
-            self.assertTrue(body[i] in face_list)
-
-    def test_roll_dice_xmas(self):
-        app = test_app.create_app(test=True)
-        tested_app = app.test_client()
-
-        # dice thrown in xmas set
-        reply = tested_app.get('/rollDice?diceset=xmas')
-        body = json.loads(str(reply.data, 'UTF8'))
-        self.assertEqual(len(body), 6)
-        for i in range(0, 6):
-            face_list = get_die_faces_lsit("xmas", i)
-            self.assertTrue(body[i] in face_list)
-
-
-
-
+def test_roll_dice_xmas(client):
+    # dice thrown in xmas set
+    reply = client.get('/rollDice?diceset=xmas')
+    body = reply.get_json()
+    assert len(body) == 6
+    for i in range(0, 6):
+        face_list = get_die_faces_lsit("xmas", i)
+        assert body[i] in face_list

--- a/monolith/tests/test_unitStories.py
+++ b/monolith/tests/test_unitStories.py
@@ -1,10 +1,9 @@
 import os
 import tempfile
 
-import pytest
+from monolith.utility.diceutils import get_die_faces_list
 
-from kombu.utils import json
-from monolith.utility.diceutils import *
+import pytest
 
 
 @pytest.fixture
@@ -26,9 +25,11 @@ def test_newStory(client):
     reply = client.get('/newStory')
     assert reply.status_code == 200
 
+
 def test_roll_valid_dice_success(client):
     reply = client.get('/rollDice?diceset=standard')
     assert reply.status_code == 200
+
 
 def test_roll_invalid_dice_fail(client):
     # new story page
@@ -47,6 +48,7 @@ def test_roll_invalid_dice_fail(client):
     reply = client.get('/rollDice?diceset=standard&dicenum=0')
     assert reply.status_code == 400
 
+
 def test_roll_dice_standard(client):
     # 6 standard dice
     reply = client.get('/rollDice?diceset=standard')
@@ -60,14 +62,16 @@ def test_roll_dice_standard(client):
     reply = client.get('/rollDice?diceset=standard&dicenum=4')
     assert len(reply.get_json()) == 4
 
+
 def test_roll_dice_halloween(client):
     # dice thrown in halloween set
     reply = client.get('/rollDice?diceset=halloween')
     body = reply.get_json()
     assert len(body) == 6
     for i in range(0, 6):
-        face_list = get_die_faces_lsit("halloween", i)
+        face_list = get_die_faces_list("halloween", i)
         assert body[i] in face_list
+
 
 def test_roll_dice_xmas(client):
     # dice thrown in xmas set
@@ -75,5 +79,5 @@ def test_roll_dice_xmas(client):
     body = reply.get_json()
     assert len(body) == 6
     for i in range(0, 6):
-        face_list = get_die_faces_lsit("xmas", i)
+        face_list = get_die_faces_list("xmas", i)
         assert body[i] in face_list

--- a/monolith/utility/diceutils.py
+++ b/monolith/utility/diceutils.py
@@ -1,15 +1,14 @@
-from monolith.definitions import *
+from monolith.definitions import RESOURCES_DIR
 
 
-def get_dice_sets_lsit():
-    f = open(RESOURCES_DIR + "/diceset.txt", "r")
-    set_list = f.read().splitlines()
-    f.close();
+def get_dice_sets_list():
+    with open(RESOURCES_DIR + '/diceset.txt', 'r') as f:
+        set_list = f.read().splitlines()
     return set_list
 
 
-def get_die_faces_lsit(setname, dienum):
-    f = open(RESOURCES_DIR + "/diceset/" + setname + "/die" + str(dienum) + ".txt", "r")
-    face_list = f.read().splitlines()
-    f.close();
+def get_die_faces_list(setname, dienum):
+    path = '{}/diceset/{}/die{}.txt'.format(RESOURCES_DIR, setname, dienum)
+    with open(path, 'r') as f:
+        face_list = f.read().splitlines()
     return face_list

--- a/monolith/views/auth.py
+++ b/monolith/views/auth.py
@@ -20,6 +20,7 @@ def login():
         user = q.first()
         if user is not None and user.authenticate(password):
             login_user(user)
+            print(current_user)
             return redirect('/')
         else:
             return jsonify({'Error': 'Wrong username or password.'})

--- a/monolith/views/auth.py
+++ b/monolith/views/auth.py
@@ -1,29 +1,30 @@
-from flask import Blueprint, render_template, redirect, request, jsonify, Response
-from flask_login import (current_user, login_user, logout_user,
-                         login_required)
+from flask import Blueprint, Response, jsonify, redirect, render_template
 
-from monolith.database import db, User
+from flask_login import current_user, login_user, logout_user
+
+from monolith.database import User, db
 from monolith.forms import LoginForm
 
+
 auth = Blueprint('auth', __name__)
+
 
 @auth.route('/login', methods=['GET', 'POST'])
 def login():
     form = LoginForm()
     form.password.errors = []
+
     if form.validate_on_submit():
         cred, password = form.data['usrn_eml'], form.data['password']
         if '@' in cred:
-            q = db.session.query(User).filter(User.email == cred)
+            user = db.session.query(User).filter(User.email == cred).first()
         else:
-            q = db.session.query(User).filter(User.username == cred)
-        user = q.first()
+            user = db.session.query(User).filter(User.username == cred).first()
         if user is not None and user.authenticate(password):
             login_user(user)
-            print(current_user)
             return redirect('/')
-        else:
-            return jsonify({'Error': 'Wrong username or password.'})
+        return jsonify({'Error': 'Wrong username or password.'})
+
     return render_template('login.html', form=form)
 
 
@@ -32,5 +33,4 @@ def logout():
     if current_user.is_authenticated:
         logout_user()
         return redirect('/')
-    else:
-        return Response(status=203)
+    return Response(status=203)

--- a/monolith/views/home.py
+++ b/monolith/views/home.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template
 
-from monolith.database import db, Story, Like
 from monolith.auth import current_user
+from monolith.database import Story, db
 
 
 home = Blueprint('home', __name__)
@@ -14,7 +14,9 @@ def _strava_auth_url(config):
 @home.route('/')
 def index():
     if current_user is not None and hasattr(current_user, 'id'):
-        stories = db.session.query(Story).filter(Story.author_id == current_user.id)
+        stories = db.session.query(Story).filter(
+            Story.author_id == current_user.id)
     else:
         stories = None
+
     return render_template("index.html", stories=stories)

--- a/monolith/views/users.py
+++ b/monolith/views/users.py
@@ -88,6 +88,6 @@ def _get_followed_dict(user_id):
 @login_required
 def get_followed():
     template_dict = _get_followed_dict(current_user.id)
-    if app.config['TESTING']:
-        return jsonify(template_dict)
+    # if app.config['TESTING']:
+    #     return jsonify(template_dict)
     return render_template('followed.html', **template_dict)

--- a/monolith/views/users.py
+++ b/monolith/views/users.py
@@ -1,5 +1,3 @@
-from os import urandom
-
 from flask import Blueprint
 from flask import abort, jsonify, redirect, render_template, request
 

--- a/monolith/views/users.py
+++ b/monolith/views/users.py
@@ -81,14 +81,13 @@ def follow(user_id):
 def _get_followed_dict(user_id):
     me = User.query.get(user_id)
     users = [{'firstname': x.firstname, 'lastname': x.lastname, 'id': x.id} for x in me.follows]
-    return users
+    return { 'users': users }
 
 
 @users.route('/followed', methods=['GET'])
 @login_required
 def get_followed():
-    users = _get_followed_dict(current_user.id)
+    template_dict = _get_followed_dict(current_user.id)
     if app.config['TESTING']:
-        return jsonify({'users': users})
-    else:
-        return render_template('followed.html', users=users)
+        return jsonify(template_dict)
+    return render_template('followed.html', **template_dict)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py36
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = pytest
        pytest-cov
+       blinker
        coveralls
        -rrequirements.txt
 


### PR DESCRIPTION
In this branch I have experimented testing with pytest fixtures. Fixtures are function that, on demand, are automatically called by the pytest application before each test, or if explicitly specified, before each session or module. Using fixtures, defined in conftest.py, we can forget about app fabrication, database creation or with block for context management and are automatically discovered by pytest, therefore no imports are needed. Extending unittest.TestCase is no longer necessary and normal function for each test can be coded with assert assuming the role of self.assertEqual. To use a fixture inside a test case an argument with the same name of the fixture must be declared, ie. `def test_case(client)` will use the client fixture if defined, for a complete example see the file test_follow.py. Fixtures can be overidden locally, eg. to use different configurations, for reference see the file test_unitStories.py where the application fabrication is overriden to disable the login functionality.
The fixtures already implemented are

- `app`: returns a new app instance with a temporary database that is isolated from other tests.
- `client`: returns a new test client instance, must be used to test request such as GET, POST or DELETE.
- `database`: returns the temporary database, populated with test data and with the correct test context. No with blocks are required inside the test functions. If the same test data is required for multiple tests, this fixture can be overriden in your local test file with different data.
- `auth`: provides an object with login and logout functions that make the login/logout request returning the reply.
- `templates`: returns the list of captured templates. No more testing code required inside the views. When a request is made, the last element of the list is populated with the context passed to the template, therefore we can test the template context to check that we return the correct values to the client. For reference see the test_followed_get function inside test_follow.py which uses this fixture.

Regular old testing code can live beside this new testing code. This branch will not be merged until we reached a consensus on whether to switch to this testing environment. In the mean time, I will add each addition to the develop branch to this branch, updating the addition to the new system, so that the transition will be as painless as possible. Some other minor fixes are implemented in particular pythonic code, typos and PEP8 compliance.

WARNING: If you want to test code locally that involves template capturing, without using tox, the blinker packages is required to install type `pip install blinker` in the virtual environment.