### PR TITLE
added .coveragerc configuration in order increase coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    */tests/conftest.py
+    */celeryapp/celery_worker.py

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,5 @@ deps = pytest
        -rrequirements.txt
 
 commands =
-    pytest --cov-config .coveragerc --cov monolith --ignore tests/conftest.py --ignore celeryapp/celery_worker.py
+    pytest --cov-config {toxinidir}/.coveragerc --cov monolith
     - coveralls


### PR DESCRIPTION
added .coveragerc configuration in order to skip celeryworker and conftest from test coverage.